### PR TITLE
Add GitHub community health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+The astro-tools community adopts the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct.
+
+All participants in astro-tools spaces — repositories, issues, pull requests, discussions, and any other community venue — are expected to follow it.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when an individual is officially representing the community in public spaces.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it by opening a confidential report via GitHub's [private vulnerability reporting](https://github.com/astro-tools/.github/security/advisories/new) on this repository, or by emailing the maintainers (contact address will be added once established).
+
+All reports will be reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and safety of the reporter.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing the standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+For the full enforcement guidelines, see the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to astro-tools
+
+Thanks for your interest in contributing! This document explains how to get involved across the astro-tools organization. Individual repositories may provide their own `CONTRIBUTING.md` that overrides or extends these defaults.
+
+## Before you start
+
+- Read the [Code of Conduct](CODE_OF_CONDUCT.md). Participation in astro-tools is governed by it.
+- Check the repo's open issues and discussions. Someone may already be working on what you have in mind.
+- For anything larger than a small fix, **open an issue first** so we can align on approach before you invest time.
+
+## Ways to contribute
+
+- **Report bugs** — open an issue using the bug report template with steps to reproduce.
+- **Suggest features or improvements** — open an issue using the feature request template.
+- **Improve documentation** — typo fixes, clarifications, and new examples are always welcome.
+- **Submit code** — fix bugs, implement features, add tests, or improve performance.
+- **Answer questions** — help others in [Discussions](https://github.com/orgs/astro-tools/discussions).
+- **Review pull requests** — thoughtful review from the community is highly valued.
+
+## Development workflow
+
+1. **Fork** the repository and clone your fork.
+2. **Create a branch** with a short, descriptive name (e.g. `fix-propagator-step`, `add-lambert-solver`).
+3. **Make your changes.** Keep commits focused and the diff minimal.
+4. **Add tests** where applicable. If a repo has a test suite, your changes should pass it.
+5. **Run linters/formatters** configured by the repo before committing.
+6. **Push** to your fork and **open a pull request** against the default branch.
+7. Fill in the pull request template. Link related issues with `Fixes #123` or `Refs #123`.
+
+## Commit messages
+
+- Use the imperative mood in the subject line: "Add Lambert solver" rather than "Added" or "Adds".
+- Keep the subject under 72 characters.
+- Use the body to explain *why* the change is being made when it is not obvious.
+- Reference issues (`Fixes #123`) where applicable.
+
+## Pull request review
+
+- A maintainer will review your PR as soon as possible. Please be patient — we are a volunteer community.
+- Expect feedback. Reviews are a conversation; changes requested are not a judgment of you or your work.
+- Keep PRs focused. Unrelated changes belong in separate PRs.
+- Keep your branch up to date with the base branch, using rebase or merge per the repo's convention.
+
+## Licensing
+
+Unless a repository states otherwise, astro-tools projects are released under the MIT License. By contributing, you agree that your contributions will be licensed under the same terms.
+
+## Questions?
+
+Open a thread in [GitHub Discussions](https://github.com/orgs/astro-tools/discussions) or ask in the relevant repository's issue tracker.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,58 @@
+# Governance
+
+This document describes how the astro-tools organization is run. It is intentionally lightweight and will evolve as the community grows.
+
+## Mission
+
+astro-tools develops open-source software for astrodynamics, mission analysis, and space operations. We aim to make mission design tools more accessible, interoperable, and reproducible.
+
+## Roles
+
+### Users
+
+Anyone who uses astro-tools software. Users are encouraged to report bugs, ask questions, and suggest improvements.
+
+### Contributors
+
+Anyone who contributes — via code, documentation, review, design, or other means. There is no formal application: open a pull request or help answer a question and you are a contributor.
+
+### Maintainers
+
+Contributors with commit rights on one or more repositories. Maintainers are responsible for:
+
+- Reviewing and merging pull requests.
+- Triaging issues.
+- Guiding the technical direction of their repository.
+- Upholding the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+New maintainers are invited by existing maintainers based on sustained, high-quality contribution and good judgment. There is no fixed threshold; invitation is by consensus of the current maintainers of the repository in question.
+
+### Organization administrators
+
+A small number of individuals have administrative rights over the GitHub organization itself (creating repositories, managing teams, etc.). Admins act on behalf of the community and follow the same decision-making processes as maintainers.
+
+## Decision making
+
+We aim for **lazy consensus**: proposals are assumed to have support unless someone objects. For most decisions, a discussion on the relevant issue or pull request is sufficient.
+
+For decisions that affect multiple repositories or the organization as a whole (e.g. adopting a new project, changing organization-wide policies), an RFC-style discussion in this repository's [Discussions](https://github.com/orgs/astro-tools/discussions) is the norm. Anyone may open one; resolution is by rough consensus among active maintainers.
+
+If consensus cannot be reached, organization administrators may make a final call, with reasoning recorded in the discussion.
+
+## Adding a new repository
+
+New repositories join the organization when:
+
+1. They fit the organization's mission.
+2. There is at least one willing maintainer.
+3. They adopt the default community health files and `LICENSE` (or equivalents).
+
+Proposals for new repositories should be opened as a Discussion before the repository is created.
+
+## Archiving or removing a repository
+
+Repositories that become unmaintained may be archived. Removal is reserved for exceptional cases (e.g. legal or licensing issues). Either action is discussed publicly before being taken.
+
+## Changes to this document
+
+This document can be changed by opening a pull request. Material changes should have broad discussion before merging.

--- a/ISSUE_TEMPLATE/bug_report.yml
+++ b/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Report something that is not working as expected.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill in the sections below so we can reproduce and fix the issue efficiently.
+
+        Before submitting, please search existing issues to avoid duplicates.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the bug.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that reliably reproduce the issue. A minimal code or script snippet is ideal.
+      placeholder: |
+        1. Set up ...
+        2. Run ...
+        3. Observe ...
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error messages, stack traces, or screenshots if applicable.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Project version
+      description: The version or commit of the astro-tools project you are using.
+      placeholder: "e.g. v0.1.0 or commit abcdef1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Operating system, language/runtime version, relevant dependencies (e.g. GMAT R2026a, Python 3.12).
+      placeholder: |
+        - OS:
+        - Language/runtime:
+        - Other relevant versions:
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help us understand the issue — logs, related issues, possible causes.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I have read the project's CONTRIBUTING.md.
+          required: false
+        - label: I agree to follow this project's Code of Conduct.
+          required: true

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & general discussion
+    url: https://github.com/orgs/astro-tools/discussions
+    about: Please ask and answer questions in GitHub Discussions rather than opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/astro-tools/.github/security/advisories/new
+    about: Please report security issues privately via GitHub's private vulnerability reporting — not as a public issue.

--- a/ISSUE_TEMPLATE/feature_request.yml
+++ b/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature request
+description: Suggest an idea or improvement for an astro-tools project.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! For larger proposals, consider opening a Discussion first so we can align on approach before anyone invests significant effort.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem are you trying to solve? What is the use case?
+      placeholder: I'm always frustrated when ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: A clear and concise description of what you would like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you have considered, and why they were rejected.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: How broad is this change?
+      options:
+        - Small (single function, minor behavior tweak)
+        - Medium (new module or noticeable behavior change)
+        - Large (new subsystem, cross-cutting, or breaking change)
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, references, prior art, diagrams, or example APIs.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checklist
+      options:
+        - label: I have searched existing issues and discussions and this is not a duplicate.
+          required: true
+        - label: I have read the project's CONTRIBUTING.md.
+          required: false
+        - label: I agree to follow this project's Code of Conduct.
+          required: true

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for contributing to astro-tools! Please fill in the sections below.
+For small changes (typo fixes, etc.) feel free to keep this brief.
+-->
+
+## Summary
+
+<!-- What does this PR do, and why? One or two sentences is usually enough. -->
+
+## Related issues
+
+<!-- Link any related issues. Use "Fixes #123" to auto-close an issue on merge, or "Refs #123" for a softer link. -->
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation update
+- [ ] Refactor / internal cleanup
+- [ ] Test-only change
+- [ ] Build / CI / tooling change
+
+## How has this been tested?
+
+<!-- Describe the tests you ran and how a reviewer can reproduce them. -->
+
+## Checklist
+
+- [ ] I have read the [Contributing Guide](https://github.com/astro-tools/.github/blob/main/CONTRIBUTING.md).
+- [ ] My change follows the repository's style and conventions.
+- [ ] I have added tests that prove my change works, or explained why none are needed.
+- [ ] New and existing tests pass locally.
+- [ ] I have updated the documentation where relevant.
+- [ ] The PR title is clear and descriptive.
+
+## Additional notes
+
+<!-- Anything reviewers should pay special attention to? Known limitations? Follow-ups? -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+The astro-tools community takes the security of its software seriously. Thank you for helping us keep our users safe.
+
+## Supported versions
+
+Individual repositories declare their own support policy. Unless otherwise stated in a repository's own `SECURITY.md`, only the latest released version of each project receives fixes.
+
+## Reporting a vulnerability
+
+**Please do not report security issues through public GitHub issues, discussions, or pull requests.**
+
+Instead, report them privately using GitHub's [private vulnerability reporting](https://github.com/astro-tools/.github/security/advisories/new) on the affected repository (or on this `.github` repository if you are unsure which repo is affected).
+
+When reporting, please include as much of the following as you can:
+
+- The repository and version affected.
+- A description of the issue and its impact.
+- Steps to reproduce, or a proof-of-concept if available.
+- Any known mitigations or workarounds.
+- Whether you plan to publicly disclose and, if so, your preferred timeline.
+
+## What to expect
+
+- We will acknowledge receipt of your report within **5 business days**.
+- We will provide an initial assessment within **10 business days**.
+- We will keep you informed of progress toward a fix and coordinate a disclosure timeline with you.
+- We will credit you in the advisory once the issue is resolved, unless you prefer to remain anonymous.
+
+## Scope
+
+This policy covers source code and published artifacts of repositories within the [`astro-tools`](https://github.com/astro-tools) GitHub organization.
+
+Out of scope:
+
+- Vulnerabilities in third-party dependencies (please report those to the respective projects; we welcome notifications so we can upgrade).
+- Issues affecting only unsupported versions.
+- Findings from automated scanners without a demonstrable impact.
+
+## Safe harbor
+
+We support good-faith security research. If you follow this policy when reporting a vulnerability to us, we will:
+
+- Consider your research authorized and will not pursue or support legal action against you.
+- Work with you to understand and resolve the issue promptly.
+
+Thank you for helping keep astro-tools and its users safe.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,40 @@
+# Support
+
+Thanks for using astro-tools! This document explains where to go for help.
+
+## Before asking for help
+
+1. **Check the repository's README and documentation.** Most common questions are answered there.
+2. **Search existing issues and discussions.** Someone may have already asked the same question.
+3. **Check the repository's `CONTRIBUTING.md`** for project-specific guidance.
+
+## Where to ask
+
+### Questions and usage help
+
+- **[GitHub Discussions](https://github.com/orgs/astro-tools/discussions)** is the best place for questions, ideas, and general conversation.
+- For project-specific questions, use the Discussions tab of the relevant repository if it has one enabled.
+
+### Bug reports
+
+- Open an issue on the affected repository using the **bug report** template.
+- Include a minimal reproducible example, the version you are using, and your environment details.
+
+### Feature requests
+
+- Open an issue on the affected repository using the **feature request** template.
+- Describe the use case, not just the proposed solution.
+
+### Security issues
+
+- **Do not file security issues publicly.** See [SECURITY.md](SECURITY.md) for our private reporting process.
+
+## What is not supported here
+
+- One-on-one technical support or consulting.
+- Homework or coursework help — we welcome conceptual questions but will not complete assignments.
+- Help with third-party tools we don't maintain (e.g. GMAT itself, SPICE, external libraries). For those, please contact the respective projects.
+
+## Response expectations
+
+astro-tools is a volunteer-driven community. Please be patient — maintainers answer questions as time allows. You are welcome and encouraged to help answer others' questions as well.


### PR DESCRIPTION
## Summary

Adds the standard set of GitHub community health files to the org `.github` repo, so they apply as defaults across all repositories in the [`astro-tools`](https://github.com/astro-tools) organization that do not provide their own equivalents.

Files added:

- `CODE_OF_CONDUCT.md` — adopts [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
- `CONTRIBUTING.md` — contribution workflow, commit style, and review expectations.
- `SECURITY.md` — private vulnerability reporting policy via GitHub security advisories, with SLAs and safe-harbor language.
- `SUPPORT.md` — where to get help and what is out of scope.
- `GOVERNANCE.md` — lightweight governance (roles, lazy consensus, how repos join/leave the org).
- `PULL_REQUEST_TEMPLATE.md` — PR template with summary, linked issues, type, testing, and checklist.
- `ISSUE_TEMPLATE/bug_report.yml` — structured bug form.
- `ISSUE_TEMPLATE/feature_request.yml` — structured feature form.
- `ISSUE_TEMPLATE/config.yml` — disables blank issues; routes questions to Discussions and security issues to private advisories.

## Rationale

GitHub's [community health file mechanism](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) lets a single set of defaults apply to every repo in the org — a good baseline while the organization is still new. Individual repos can override any file locally as they mature.

## Notes for reviewers

- The `CODE_OF_CONDUCT.md` links to the Contributor Covenant rather than inlining the full text, for maintainability.
- Security reports are routed to this `.github` repo's advisories until individual repos have their own security configured.
- No email address is listed yet; an astro-tools contact address can be added in a follow-up once established.

## Test plan

- [ ] Verify the Community Standards page on the repo shows all items as met after merge (Insights → Community Standards).
- [ ] Open a test issue on a repo without its own templates to confirm the forms appear.
- [ ] Confirm "Report a security vulnerability" in the Security tab uses the private advisory flow.