### PR TITLE
Feature gmat-run under Featured repositories

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -16,7 +16,7 @@ Open-source tooling for astrodynamics, mission analysis, and space operations.
 
 ## Featured repositories
 
-*Coming soon — repositories will be listed here as the organization grows.*
+- **[gmat-run](https://github.com/astro-tools/gmat-run)** — Run GMAT mission scripts from Python and get results as pandas DataFrames.
 
 ## How to contribute
 


### PR DESCRIPTION
## Summary
- Replace the "Coming soon" placeholder in the org profile README with a bullet linking to [`astro-tools/gmat-run`](https://github.com/astro-tools/gmat-run), the first product repo in the org.

## Test plan
- [ ] Preview the rendered org profile at https://github.com/astro-tools and confirm the Featured repositories section shows the `gmat-run` link.